### PR TITLE
Fix collapse menu position, CSS adjustments

### DIFF
--- a/src/css/bootstrap-navbar.css
+++ b/src/css/bootstrap-navbar.css
@@ -93,6 +93,7 @@
       padding-top: .7em;
       padding-bottom: .7em;
       top: 5.5rem;
+      right: 1em;
 
       -webkit-box-shadow: inset 0 0 1em 0.25em rgba(0,0,0,0.75);
       -moz-box-shadow: inset 0 0 1em 0.25em rgba(0,0,0,0.75);

--- a/src/css/page_portfolio.css
+++ b/src/css/page_portfolio.css
@@ -1,6 +1,7 @@
 .portfolio > .row>* {
+    padding-left: 0;
+    padding-right: 0;
     margin-bottom: .5em;
-
     border-radius: 1em;
 }
 
@@ -11,7 +12,7 @@
 
 .portfolio .col-content {
     padding: 1em;
-    background-color: rgba(0, 0, 0, 0.85);
+    background-color: rgba(0, 0, 0, 0.75);
     border-radius: 1em;
 }
 


### PR DESCRIPTION
- Remove padding from portfolio containers on mobile
- Move collapse menu back to right on mobile
- Lighten backgrounds of portfolio boxes by 10%