### PR TITLE
Remove scrollbar, adjust collapse menu CSS

### DIFF
--- a/src/css/bootstrap-navbar.css
+++ b/src/css/bootstrap-navbar.css
@@ -97,9 +97,10 @@
 
       -webkit-box-shadow: inset 0 0 1em 0.25em rgba(0,0,0,0.75);
       -moz-box-shadow: inset 0 0 1em 0.25em rgba(0,0,0,0.75);
-      box-shadow: inset 0 0 1em 0.25em rgba(0,0,0,0.75);
+      box-shadow: inset 0 0 1em 0.25em rgba(0,0,0,0.75),
+      -0.25em .75em 1.5em 2em rgba(0,0,0,.95);
       
-      background-color: rgba(0,0,0,0.75);
+      background-color: rgba(13, 0, 29, 1);
       border-radius: 1em;
       
       opacity: 1;

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -125,6 +125,13 @@ button:focus-visible {
   
   background-size: cover;
   background-position: center;
+  
+  -ms-overflow-style: none;  /* Internet Explorer 10+ */
+  scrollbar-width: none;  /* Firefox */
+}
+
+.page::-webkit-scrollbar {
+  display: none;  /* Safari and Chrome */
 }
 
 .page-enter {


### PR DESCRIPTION
- Add shadow to collapse menu on mobile
- Change bgcolor of collapse menu to dark purple
- Remove scrollbar of page container (scrolling still allowed)